### PR TITLE
Update BMW X4 generations: Add end year for second generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# BMW X4
 
+This repository contains signal set configurations for the BMW X4, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the BMW X4.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/BMW_X4"
+
 generations:
   - name: "First Generation (F26)"
     start_year: 2014
@@ -6,5 +9,5 @@ generations:
 
   - name: "Second Generation (G02)"
     start_year: 2018
-    end_year: null
-    description: "The current X4 is based on the G01 X3 platform but features more differentiated styling than its predecessor, with a longer wheelbase, wider track, and lower height creating a more athletic profile. The interior offers similar technology and features to the X3 but with a more driver-focused layout. Engine options range from efficient four-cylinders to the high-performance X4 M with up to 503 HP from its twin-turbocharged six-cylinder engine. All models feature xDrive all-wheel drive and an automatic transmission as standard. A facelift in 2021 updated the exterior styling and interior technology, including a larger infotainment display and enhanced digital features. The second-generation X4 continues to cater to buyers seeking a more emotionally styled alternative to traditional SUVs, offering a compromise between utility and sporty design."
+    end_year: 2025
+    description: "The current X4 is based on the G01 X3 platform but features more differentiated styling than its predecessor, with a longer wheelbase, wider track, and lower height creating a more athletic profile. The interior offers similar technology and features to the X3 but with a more driver-focused layout. Engine options range from efficient four-cylinders to the high-performance X4 M with up to 503 HP from its twin-turbocharged six-cylinder engine. All models feature xDrive all-wheel drive and an automatic transmission as standard. A facelift in 2021 updated the exterior styling and interior technology, including a larger infotainment display and enhanced digital features. The second-generation X4 continues to cater to buyers seeking a more emotionally styled alternative to traditional SUVs, offering a compromise between utility and sporty design. BMW has indicated 2025 will be the X4's final model year."


### PR DESCRIPTION
- Set second generation (G02) end_year to 2025 per Wikipedia
- Added note that 2025 is the final model year for X4
- Added Wikipedia reference URL
- Updated README.md with standard template

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
